### PR TITLE
Setup for the latest JEC derivations using offline PFHCs

### DIFF
--- a/JESCorrections/test/config/jra_hltRun3.config
+++ b/JESCorrections/test/config/jra_hltRun3.config
@@ -11,7 +11,13 @@ $ algorithms [format: algorithm:drmax]
 $
 $algs = 
 
-binspt = 1  10   15   20   25   30   35   40   45   57   72   90   120   150
+$ Pt binning for the fits:
+$ Older binning with coarser bins at low pt
+$binspt = 1  10   15   20   25   30   35   40   45   57   72   90   120   150
+$         200   300   400   550   750   1000   1500   2000   2500   3000   5000   10000
+
+$ More recent binning with finer bins at low pt
+binspt = 1  10   15   18   21   24   27   30   35   40   45   50   60   70   80   100   120   150
          200   300   400   550   750   1000   1500   2000   2500   3000   5000   10000
 
 $binseta = -5.1, -4.8, -4.5, -4.2, -3.9, -3.6, -3.3, -3.0,

--- a/JESCorrections/test/crab/sub_flatPU.py
+++ b/JESCorrections/test/crab/sub_flatPU.py
@@ -1,6 +1,6 @@
 from CRABClient.UserUtilities import config
 
-sample_name = 'flatPU0to120_Flat2018_Run3_126X_CMSSW_13_0_0'
+sample_name = 'QCD_FlatPUGTv6HCAL_126X_withForwardPFHCs'
 
 RAW_DSET = '/QCD_PT-15to7000_TuneCP5_Flat2022_13p6TeV_pythia8/Run3Winter23Digi-FlPU0to80GTv6HC_126X_mcRun3_2023_forPU65_v6_withHCALResCor_ext1-v2/GEN-SIM-RAW'
 
@@ -17,7 +17,6 @@ config.JobType.psetName = 'jescJRA_cfg.py'
 config.JobType.inputFiles = []
 config.JobType.pyCfgParams = ['output='+sample_name+'.root']
 config.JobType.maxMemoryMB = 2500
-config.JobType.inputFiles = ['PFCalibration.db']
 config.JobType.allowUndistributedCMSSW = True
 
 config.section_('Data')
@@ -25,10 +24,10 @@ config.Data.publication = False
 config.Data.ignoreLocality = False
 config.Data.splitting = 'Automatic'
 config.Data.inputDataset = RAW_DSET
-config.Data.outLFNDirBase = '/store/user/chuh/hlt_runIII_jesc_2023_v6/'+sample_name
+config.Data.outLFNDirBase = '/store/user/aakpinar/nanopost/hlt_run3_JECs/'+sample_name
 config.Data.unitsPerJob = 200
 config.Data.totalUnits = -1
 
 config.section_('Site')
-config.Site.storageSite = 'T3_KR_KNU'
+config.Site.storageSite = 'T3_CH_CERNBOX'
 config.section_('User')

--- a/JESCorrections/test/crab/sub_noPU.py
+++ b/JESCorrections/test/crab/sub_noPU.py
@@ -1,6 +1,6 @@
 from CRABClient.UserUtilities import config
 
-sample_name = 'EpsilonPU_Flat2018_Run3_126X_CMSSW_13_0_0'
+sample_name = 'QCD_EpsPUGTv6HCAL_126X_withForwardPFHCs'
 
 RAW_DSET = '/QCD_PT-15to7000_TuneCP5_Flat2022_13p6TeV_pythia8/Run3Winter23Digi-EpsPUGTv6HCAL_126X_mcRun3_2023_forPU65_v6_withHCALResCor_ext1-v2/GEN-SIM-RAW'
 
@@ -17,7 +17,6 @@ config.JobType.psetName = 'jescJRA_cfg.py'
 config.JobType.inputFiles = []
 config.JobType.pyCfgParams = ['output='+sample_name+'.root']
 config.JobType.maxMemoryMB = 2500
-config.JobType.inputFiles = ['PFCalibration.db']
 config.JobType.allowUndistributedCMSSW = True
 
 config.section_('Data')
@@ -25,10 +24,10 @@ config.Data.publication = False
 config.Data.ignoreLocality = False
 config.Data.splitting = 'Automatic'
 config.Data.inputDataset = RAW_DSET
-config.Data.outLFNDirBase = '/store/user/chuh/hlt_runIII_jesc_2023_v6/'+sample_name
+config.Data.outLFNDirBase = '/store/user/aakpinar/nanopost/hlt_run3_JECs/'+sample_name
 config.Data.unitsPerJob = 200
 config.Data.totalUnits = -1
 
 config.section_('Site')
-config.Site.storageSite = 'T3_KR_KNU'
+config.Site.storageSite = 'T3_CH_CERNBOX'
 config.section_('User')

--- a/JESCorrections/test/fitJESCs
+++ b/JESCorrections/test/fitJESCs
@@ -6,8 +6,14 @@ set -euo pipefail
 ## -------------------------
 JESC_BASE=${CMSSW_BASE}/src/JMETriggerAnalysis/JESCorrections/test
 
-JRANTuple_NoPU=/eos/cms/store/user/chuh/jec/v6/jmeTriggerNTuple_EpsilonPU.root
-JRANTuple_PU=/eos/cms/store/user/chuh/jec/v6/jmeTriggerNTuple_PU0to80.root
+# Merged samples without forward (|eta| > 2.5) PFHCs applied
+JRANTuple_NoPU=/eos/user/a/aakpinar/nanopost/hlt_run3_JECs/samples_merged/QCD_EpsPUGTv6HCAL_126X/0000.root
+JRANTuple_PU=/eos/user/a/aakpinar/nanopost/hlt_run3_JECs/samples_merged/QCD_FlatPUGTv6HCAL_126X/0000.root
+
+# Merged samples with forward (|eta| > 2.5) PFHCs applied
+# JRANTuple_NoPU=/eos/user/a/aakpinar/nanopost/hlt_run3_JECs/samples_merged/QCD_EpsPUGTv6HCAL_126X_withForwardPFHCs/0000.root
+# JRANTuple_PU=/eos/user/a/aakpinar/nanopost/hlt_run3_JECs/samples_merged/QCD_FlatPUGTv6HCAL_126X_withForwardPFHCs/0000.root
+
 #JRANTuple_NoPU=root://eoscms.cern.ch//eos/cms/store/user/chuh/jec/jmeTriggerNTuple_NoPU.root
 #JRANTuple_PU=root://eoscms.cern.ch//eos/cms/store/user/chuh/jec/jmeTriggerNTuple_PU0to120.root
 
@@ -211,7 +217,7 @@ runJECWorflowForOneAlgo(){
     CMD_STEP="jet_l2_correction_x -algs ${jetType} -era ${ERA} -l2l3 true"
     CMD_STEP+=" -input plots_${stepNameOld}/histogram_${jetType}l1_${stepNameOld}.root -outputDir ./ -output l2p3.root"
     CMD_STEP+=" -makeCanvasVariable AbsCorVsJetPt:JetEta -batch true -histMet median -l2pffit standard+Gaussian -maxFitIter 50"
-    CMD_STEP+=" -ptclipfit true -ptclip 10.0"
+    CMD_STEP+=" -ptclipfit false -ptclip 10.0"
     stepCmd "mkdir -p plots_${stepName}\n\n${CMD_STEP}" ${stepName}
   fi
 

--- a/JESCorrections/test/sub_jecs.htc
+++ b/JESCorrections/test/sub_jecs.htc
@@ -1,35 +1,37 @@
 executable            = fitJESCs
 getenv                = True
 should_transfer_files = YES
-#when_to_transfer_output = ON_EXIT_OR_EVICT
-#transfer_output_files = jescs_10M_v6
-output_destination = root://eosuser.cern.ch//eos/user/c/chuh/PFHC/CMSSW_13_0_7_patch1/src/JMETriggerAnalysis/JESCorrections/test/$(ClusterId)/
+when_to_transfer_output = ON_EXIT_OR_EVICT
+transfer_output_files = JESCs_noForwardPFHCs_10M_noPtClip
+output_destination = /afs/cern.ch/work/a/aakpinar/public/CMSSW_13_0_7_patch1/src/JMETriggerAnalysis/JESCorrections/test/
+
 MY.XRDCP_CREATE_DIR = True
+MY.WantOS = "el8"
 
-arguments             =  -o jescs_10M_fixpfhc -n 10000000 -b -j ak4caloHLT
-output                = htc_out/ak4caloHLT_10M.out
-error                 = htc_out/ak4caloHLT_10M.err
-log                   = htc_out/ak4caloHLT_10M.log
+arguments             =  -o JESCs_noForwardPFHCs_10M_noPtClip -b -j ak4caloHLT -n 10000000
+output                = htc_out_noForwardPFHCs_10M_noPtClip/ak4caloHLT.out
+error                 = htc_out_noForwardPFHCs_10M_noPtClip/ak4caloHLT.err
+log                   = htc_out_noForwardPFHCs_10M_noPtClip/ak4caloHLT.log
 +JobFlavour           = "tomorrow"
 queue
 
-arguments             =  -o jescs_10M_fixpfhc -n 10000000 -b -j ak4pfHLT
-output                = htc_out/ak4pfHLT_10M.out
-error                 = htc_out/ak4pfHLT_10M.err
-log                   = htc_out/ak4pfHLT_10M.log
+arguments             =  -o JESCs_noForwardPFHCs_10M_noPtClip -b -j ak4pfHLT -n 10000000
+output                = htc_out_noForwardPFHCs_10M_noPtClip/ak4pfHLT.out
+error                 = htc_out_noForwardPFHCs_10M_noPtClip/ak4pfHLT.err
+log                   = htc_out_noForwardPFHCs_10M_noPtClip/ak4pfHLT.log
 +JobFlavour           = "tomorrow"
 queue
 
-arguments             =  -o jescs_10M_fixpfhc -n 10000000 -b -j ak8caloHLT
-output                = htc_out/ak8caloHLT_10M.out
-error                 = htc_out/ak8caloHLT_10M.err
-log                   = htc_out/ak8caloHLT_10M.log
+arguments             =  -o JESCs_noForwardPFHCs_10M_noPtClip -b -j ak8caloHLT -n 10000000
+output                = htc_out_noForwardPFHCs_10M_noPtClip/ak8caloHLT.out
+error                 = htc_out_noForwardPFHCs_10M_noPtClip/ak8caloHLT.err
+log                   = htc_out_noForwardPFHCs_10M_noPtClip/ak8caloHLT.log
 +JobFlavour           = "tomorrow"
 queue
 
-arguments             =  -o jescs_10M_fixpfhc -n 10000000 -b -j ak8pfHLT
-output                = htc_out/ak8pfHLT_10M.out
-error                 = htc_out/ak8pfHLT_10M.err
-log                   = htc_out/ak8pfHLT_10M.log
+arguments             =  -o JESCs_noForwardPFHCs_10M_noPtClip -b -j ak8pfHLT -n 10000000
+output                = htc_out_noForwardPFHCs_10M_noPtClip/ak8pfHLT.out
+error                 = htc_out_noForwardPFHCs_10M_noPtClip/ak8pfHLT.err
+log                   = htc_out_noForwardPFHCs_10M_noPtClip/ak8pfHLT.log
 +JobFlavour           = "tomorrow"
 queue

--- a/NTupleAnalysis/test/addNTuples_2023MC.sh
+++ b/NTupleAnalysis/test/addNTuples_2023MC.sh
@@ -2,17 +2,18 @@
 source env.sh
 
 # directory with input(s) 
-INPDIR=/eos/user/t/tchatzis/samples2023/test_noCustom
+INPDIR=/eos/user/a/aakpinar/nanopost/hlt_run3_JECs
 
-mkdir -p ${INPDIR}/HLT_Run3TRK/samples_merged
+mkdir -p ${INPDIR}/samples_merged/QCD_FlatPUGTv6HCAL_126X_withForwardPFHCs
+mkdir -p ${INPDIR}/samples_merged/QCD_EpsPUGTv6HCAL_126X_withForwardPFHCs
 
-# QCD
-hadd_ntuples.py -i ${INPDIR}/HLT_Run3TRK/Run3Winter23_QCD_Pt15to7000_13p6TeV_PU65 \
--o ${INPDIR}/HLT_Run3TRK/samples_merged -l 0
+# QCD flat PU sample
+hadd_ntuples.py -i ${INPDIR}/QCD_FlatPUGTv6HCAL_126X_withForwardPFHCs/QCD_PT-15to7000_TuneCP5_Flat2022_13p6TeV_pythia8/crab_jmeTriggerNTuple_QCD_FlatPUGTv6HCAL_126X_withForwardPFHCs/230802_122038/0000 \
+-o ${INPDIR}/samples_merged/QCD_FlatPUGTv6HCAL_126X_withForwardPFHCs -l 0
 
-# VBF HToInvisible
-hadd_ntuples.py -i ${INPDIR}/HLT_Run3TRK/Run3Winter23_VBF_HToInvisible_13p6TeV_PU65 \
--o ${INPDIR}/HLT_Run3TRK/samples_merged -l 0
+# QCD epsilon PU sample
+hadd_ntuples.py -i ${INPDIR}/QCD_EpsPUGTv6HCAL_126X_withForwardPFHCs/QCD_PT-15to7000_TuneCP5_Flat2022_13p6TeV_pythia8/crab_jmeTriggerNTuple_QCD_EpsPUGTv6HCAL_126X_withForwardPFHCs/230802_121934/0000 \
+-o ${INPDIR}/samples_merged/QCD_EpsPUGTv6HCAL_126X_withForwardPFHCs -l 0
 
 
 


### PR DESCRIPTION
Latest JEC derivation setup. Following changes are in this PR:

* HTCondor submission scripts are fixed for Enterprise Linux8 (`lxplus8`) by adding `MY.WantOS = "el8"`
* `-ptclip false` option is introduced to avoid the flat term at low pt (pt < 10) while doing JEC fits
* A finer binning at low pt is also used for the individual fits
